### PR TITLE
クイズの出題のランダム化

### DIFF
--- a/src/main/java/oit/is/quizknockn/yonhaya/controller/YonhayaController.java
+++ b/src/main/java/oit/is/quizknockn/yonhaya/controller/YonhayaController.java
@@ -1,6 +1,7 @@
 package oit.is.quizknockn.yonhaya.controller;
 
 import java.security.Principal;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +39,7 @@ public class YonhayaController {
 
   // デモ用のクイズインデックス
   private int quizIndex = 1;
+  private int maxquizINdex = 10;
 
   @GetMapping("")
   public String sample21() {
@@ -68,6 +70,8 @@ public class YonhayaController {
 
   @GetMapping("quiz")
   public String Shift_Quiz(ModelMap model) {
+    // quizIndexを1から10のランダムな値に設定
+    quizIndex = ThreadLocalRandom.current().nextInt(1, maxquizINdex + 1);
     Quiz quiz = quizMapper.selectById(quizIndex);
     QuizChoices quizChoices = quizChoicecsMapper.selectById(quizIndex);
     model.addAttribute("quiz", quiz);


### PR DESCRIPTION
クイズの出題のランダム化をしました。
編集したファイルは、　YonhayaController.javaです。

補足
現在クイズのランダム化を行う上で、ログインしているそれぞれのユーザがランダムにクイズを選び主題されているため、ユーザ間のクイズの同一性が取れていない。そのため、ユーザ間でのクイズの同一性を確保するために、管理者を用いたクイズ処理かroom.java内であらかじめ出題するクイズをランダムに決める必要があると考える。
また、来週の授業中に一緒に考えよ。