### PR TITLE
結果発表のリンクを全員解き終わった後に表示する

### DIFF
--- a/src/main/java/oit/is/quizknockn/yonhaya/controller/YonhayaController.java
+++ b/src/main/java/oit/is/quizknockn/yonhaya/controller/YonhayaController.java
@@ -52,7 +52,9 @@ public class YonhayaController {
   private int currentQuestionIndex = 0;
   private int j = 0;
   private int quizID = 1;
+  private int finishNumber = 0;
   private final int MAX_QUESTIONS = 2;
+  private final int MAX_USER_NUMBER = 2;
   private int scoreWeight = 4;
 
   @GetMapping("")
@@ -130,7 +132,10 @@ public class YonhayaController {
     asyncWaitRoom.userWait();
 
     if (MAX_QUESTIONS <= currentQuestionIndex) {
-      model.addAttribute("finish", 1);
+      finishNumber++;
+    }
+    if (finishNumber == MAX_USER_NUMBER) {
+      asyncWaitRoom.quizFinish();
     }
 
     model.addAttribute("result", result);

--- a/src/main/java/oit/is/quizknockn/yonhaya/model/UserWaitRoom.java
+++ b/src/main/java/oit/is/quizknockn/yonhaya/model/UserWaitRoom.java
@@ -1,0 +1,31 @@
+package oit.is.quizknockn.yonhaya.model;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserWaitRoom {
+  private int waitingUser = 0;
+  private boolean finishFlag = false;
+
+  public void clear() {
+    waitingUser = 0;
+    finishFlag = false;
+  }
+
+  public int getWaitingUser() {
+    return waitingUser;
+  }
+
+  public void setWaitingUser(int waitingUser) {
+    this.waitingUser = waitingUser;
+  }
+
+  public void setFinishFlag(boolean finishFlag) {
+    this.finishFlag = finishFlag;
+  }
+
+  public boolean isFinishFlag() {
+    return finishFlag;
+  }
+
+}

--- a/src/main/java/oit/is/quizknockn/yonhaya/service/AsyncWaitRoom.java
+++ b/src/main/java/oit/is/quizknockn/yonhaya/service/AsyncWaitRoom.java
@@ -6,24 +6,37 @@ import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import oit.is.quizknockn.yonhaya.model.UserWaitRoom;
 
 @Service
 public class AsyncWaitRoom {
   private final Logger logger = LoggerFactory.getLogger(AsyncWaitRoom.class);
 
-  private int waitingUser = 0;
+  @Autowired
+  private UserWaitRoom userWaitRoom;
+
   private boolean userUpdate = false;
+
+  private final int MAX_USER_NUMBER = 2;
 
   @Async
   public void userWait() {
     logger.info("User Enters a Room");
-    waitingUser++;
+    userWaitRoom.setWaitingUser(userWaitRoom.getWaitingUser() + 1);
     this.userUpdate = true;
   }
 
   public void clearWait() {
-    waitingUser = 0;
+    userWaitRoom.clear();
     userUpdate = false;
+  }
+
+  public void quizFinish() {
+
+    userWaitRoom.setFinishFlag(true);
+
   }
 
   @Async
@@ -42,7 +55,7 @@ public class AsyncWaitRoom {
         logger.info("send(RoomUsers)");
         TimeUnit.MILLISECONDS.sleep(100);// 0.1秒STOP
         // JSONオブジェクトがクライアントに送付される
-        emitter.send(waitingUser);
+        emitter.send(userWaitRoom);
         userUpdate = false;
 
       } catch (Exception e) {

--- a/src/main/resources/templates/wait.html
+++ b/src/main/resources/templates/wait.html
@@ -7,15 +7,21 @@
       const sse = new EventSource('/yonhaya/waitInfo');
       sse.onmessage = function (event) {
         console.log("sse.onmessage");
-        var user_number = JSON.parse(event.data);
+        var userWaitRoom = JSON.parse(event.data);
+        var user_number = userWaitRoom.waitingUser;
+        var finish_flag = userWaitRoom.finishFlag;
         var results = "<a>他の人の解答を待ってます！</a>";
 
+        if (finish_flag) {
+          results += "<a href='/yonhaya/finish'>結果発表</a>"
+        }
         if (user_number == 2) {
           // 数秒待機してからクイズ画面に遷移
           setTimeout(function () {
             window.location.href = '/yonhaya/quiz';
           }, 2000); // 2秒
         }
+
 
         document.getElementById("waitInfo").innerHTML = results;
 
@@ -28,6 +34,3 @@
   [[${result}]]
 </div>
 <div id="waitInfo"></div>
-<div th:if="${finish}">
-  <a href="/yonhaya/finish">結果発表</a>
-</div>


### PR DESCRIPTION
結果発表のリンクを全員解き終わった後（正誤判定が行われた後）に表示するようにしました．
SSEemitterでsendするデータを参照するために，UserWaitRoom.javaをmodelに追加しました．

その他編集したファイル
・wait.html
・YonhayaController.java
・AsyncWaitRoom.java