### PR TITLE
結果発表のリンクの表示を修正

### DIFF
--- a/src/main/java/oit/is/quizknockn/yonhaya/controller/YonhayaController.java
+++ b/src/main/java/oit/is/quizknockn/yonhaya/controller/YonhayaController.java
@@ -203,6 +203,12 @@ public class YonhayaController {
   @GetMapping("exit")
   public String exit(Principal prin) {
     String loginUser = prin.getName();
+    resetGame(loginUser);
+
+    return "4haya.html";
+  }
+
+  private void resetGame(String loginUser) {
     userMapper.updateByUserIsActive(loginUser, false);
     userMapper.setPointZero();
     userMapper.setRankZero();
@@ -211,7 +217,8 @@ public class YonhayaController {
     quizID = 1;
     asyncJoinRoom.clearuserJoin();
     asyncWaitRoom.clearWait();
-    return "4haya.html";
+    finishNumber = 0;
+
   }
 
 }


### PR DESCRIPTION
２回目以降の試合で常に結果発表のリンクが表示されていた問題を解決しました．
原因は変数の初期化を忘れていたことでした．
リセット用の関数にまとめました．

編集したファイル
・YonhayaController.java