### PR TITLE
これまでの試合結果表示

### DIFF
--- a/src/main/java/oit/is/quizknockn/yonhaya/controller/YonhayaController.java
+++ b/src/main/java/oit/is/quizknockn/yonhaya/controller/YonhayaController.java
@@ -61,11 +61,17 @@ public class YonhayaController {
   private final int MAX_QUESTIONS = 2;
   private final int MAX_USER_NUMBER = 2;
   private int scoreWeight = 4;
+  // 試合回数の記録用
+  private int Match_history = 0;
+  private int Match_history_flag = 0;
 
   @GetMapping("")
   public String showHomePage(Principal prin, ModelMap model) {
     User loginUser = userMapper.selectByUserName(prin.getName());
     model.addAttribute("loginUser", loginUser);
+    if (Match_history > 0) {
+      model.addAttribute("Match_history", Match_history);
+    }
     return "4haya.html";
   }
 
@@ -212,11 +218,28 @@ public class YonhayaController {
   }
 
   @GetMapping("exit")
-  public String exit(Principal prin) {
+  public String exit(ModelMap model, Principal prin) {
     String loginUser = prin.getName();
     resetGame(loginUser);
 
+    if (Match_history_flag == 0) {
+      Match_history++;
+      Match_history_flag++;
+    } else if (Match_history_flag != 0) {
+      Match_history_flag++;
+    } else if (Match_history_flag == 2) {
+      Match_history_flag = 0;
+    }
+    model.addAttribute("Match_history", Match_history);
+
     return "4haya.html";
+  }
+
+  @GetMapping("Match_history")
+  public String Match_History(ModelMap model) {
+    ArrayList<MatchResult> Match_Result = matchResultMapper.selectMatchResultByAll();
+    model.addAttribute("Match_Result", Match_Result);
+    return "MatchHistory.html";
   }
 
   private void resetGame(String loginUser) {

--- a/src/main/java/oit/is/quizknockn/yonhaya/model/MatchResultMapper.java
+++ b/src/main/java/oit/is/quizknockn/yonhaya/model/MatchResultMapper.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
 
 @Mapper
@@ -17,4 +16,7 @@ public interface MatchResultMapper {
 
   @Select("Select * from MatchResult where roomNo = #{roomNo}")
   ArrayList<MatchResult> selectMatchResultByRoomNo(int roomNo);
+
+  @Select("Select * from MatchResult")
+  ArrayList<MatchResult> selectMatchResultByAll();
 }

--- a/src/main/resources/templates/4haya.html
+++ b/src/main/resources/templates/4haya.html
@@ -2,6 +2,10 @@
   <a href="/yonhaya/di">入室(DI)</a><br>
   <a href="/yonhaya/help">ゲームのヘルプ</a>
 
+  <div th:if="${Match_history}">
+    <a href="/yonhaya/Match_history">これまでの試合結果([[${Match_history}]])</a>
+  </div>
+
   <div th:if="${error}">
     [[${error}]]はすでに入室されています。
   </div>

--- a/src/main/resources/templates/MatchHistory.html
+++ b/src/main/resources/templates/MatchHistory.html
@@ -1,0 +1,11 @@
+<body>
+  <a href="/yonhaya">戻る</a>
+  <div th:if="${Match_Result}">
+    <div th:each="matchresult, stat : ${Match_Result}">
+      <p>ルームナンバー : [[${matchresult.roomNo}]]</p>
+      <p>ユーザ名 : [[${matchresult.userName}]]</p>
+      <p>得点 : [[${matchresult.point}]]点</p>
+      <p>順位 : [[${matchresult.rank}]]位</p>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
一度試合が終了してから、再度ログインすると、4haya.htmlの中に「これまでの試合結果(試合した数)」というリンクを作成し、MatchHistory.htmlを表示できるようにした。
また、MatchHistory.htmlにはこれまでの試合結果(ルームナンバー、ユーザ名、ポイント、ランキング順位)を表示するようにした。
さらに、「戻る」というリンクをクリックして、戻っても「これまでの試合(試合した数)」が表示されるようにした。
【編集したファイル】
YonhayaController.java、MatchResultMapper.java、4haya.html
【作成したファイル】
MatchHistory.html
